### PR TITLE
Fixed check for source being null or empty

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -150,7 +150,7 @@ public class JobValidator {
         errors.add("Volume path is not absolute: " + path);
         continue;
       }
-      if (!isNullOrEmpty(source) && !source.startsWith("/")) {
+      if (isNullOrEmpty(source) && !source.startsWith("/")) {
         errors.add("Volume source is not absolute: " + source);
         continue;
       }


### PR DESCRIPTION
This bug was hidden by the second condition which is normally always false and was only discovered when I disabled this second condition to allow the usage of named volumes which don't start with a '/'.