### PR TITLE
Separate checks if volume source is valid

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -150,7 +150,11 @@ public class JobValidator {
         errors.add("Volume path is not absolute: " + path);
         continue;
       }
-      if (isNullOrEmpty(source) && !source.startsWith("/")) {
+      if (isNullOrEmpty(source)) {
+        errors.add("Volume source is null or empty");
+        continue;
+      }
+      if (!source.startsWith("/")) {
         errors.add("Volume source is not absolute: " + source);
         continue;
       }


### PR DESCRIPTION
Separated the checks for the volume source so that there isn't a NPE if the source is null.